### PR TITLE
Refactor from pkg_resources to importlib.resources

### DIFF
--- a/face_recognition_models/__init__.py
+++ b/face_recognition_models/__init__.py
@@ -4,17 +4,22 @@ __author__ = """Adam Geitgey"""
 __email__ = 'ageitgey@gmail.com'
 __version__ = '0.1.0'
 
-from pkg_resources import resource_filename
+try:
+    # Python 3.9+
+    from importlib.resources import files
+except ImportError:
+    # Python 3.7-3.8 fallback
+    from importlib_resources import files
 
 def pose_predictor_model_location():
-    return resource_filename(__name__, "models/shape_predictor_68_face_landmarks.dat")
+    return str(files(__name__).joinpath("models", "shape_predictor_68_face_landmarks.dat"))
 
 def pose_predictor_five_point_model_location():
-    return resource_filename(__name__, "models/shape_predictor_5_face_landmarks.dat")
+    return str(files(__name__).joinpath("models", "shape_predictor_5_face_landmarks.dat"))
 
 def face_recognition_model_location():
-    return resource_filename(__name__, "models/dlib_face_recognition_resnet_model_v1.dat")
+    return str(files(__name__).joinpath("models", "dlib_face_recognition_resnet_model_v1.dat"))
 
 def cnn_face_detector_model_location():
-    return resource_filename(__name__, "models/mmod_human_face_detector.dat")
+    return str(files(__name__).joinpath("models", "mmod_human_face_detector.dat"))
 


### PR DESCRIPTION
Eliminate startup warning by replacing  pkg_resources with importlib.resources.files() for accessing package data files. Includes fallback to importlib_resources  for Python 3.7-3.8 compatibility.