### PR TITLE
Replace deprecated pkg_resources with importlib.resources

### DIFF
--- a/face_recognition_models/__init__.py
+++ b/face_recognition_models/__init__.py
@@ -4,17 +4,17 @@ __author__ = """Adam Geitgey"""
 __email__ = 'ageitgey@gmail.com'
 __version__ = '0.1.0'
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 def pose_predictor_model_location():
-    return resource_filename(__name__, "models/shape_predictor_68_face_landmarks.dat")
+    return str(files(__name__).joinpath("models/shape_predictor_68_face_landmarks.dat")
 
 def pose_predictor_five_point_model_location():
-    return resource_filename(__name__, "models/shape_predictor_5_face_landmarks.dat")
+    return str(files(__name__).joinpath("models/shape_predictor_5_face_landmarks.dat")
 
 def face_recognition_model_location():
-    return resource_filename(__name__, "models/dlib_face_recognition_resnet_model_v1.dat")
+    return str(files(__name__).joinpath("models/dlib_face_recognition_resnet_model_v1.dat")
 
 def cnn_face_detector_model_location():
-    return resource_filename(__name__, "models/mmod_human_face_detector.dat")
+    return str(files(__name__).joinpath("models/mmod_human_face_detector.dat")
 

--- a/face_recognition_models/__init__.py
+++ b/face_recognition_models/__init__.py
@@ -7,14 +7,14 @@ __version__ = '0.1.0'
 from importlib.resources import files
 
 def pose_predictor_model_location():
-    return str(files(__name__).joinpath("models/shape_predictor_68_face_landmarks.dat")
+    return str(files(__name__).joinpath("models/shape_predictor_68_face_landmarks.dat"))
 
 def pose_predictor_five_point_model_location():
-    return str(files(__name__).joinpath("models/shape_predictor_5_face_landmarks.dat")
+    return str(files(__name__).joinpath("models/shape_predictor_5_face_landmarks.dat"))
 
 def face_recognition_model_location():
-    return str(files(__name__).joinpath("models/dlib_face_recognition_resnet_model_v1.dat")
+    return str(files(__name__).joinpath("models/dlib_face_recognition_resnet_model_v1.dat"))
 
 def cnn_face_detector_model_location():
-    return str(files(__name__).joinpath("models/mmod_human_face_detector.dat")
+    return str(files(__name__).joinpath("models/mmod_human_face_detector.dat"))
 


### PR DESCRIPTION
This fixes the deprecation warning by migrating from pkg_resources to importlib.resources.

Changes:
- Replaced 'from pkg_resources import resource_filename' with 'from importlib.resources import files'
- Updated all resource_filename(__name__, path) calls to str(files(__name__).joinpath(path))

This ensures compatibility with Python 3.7+ and Setuptools >= 81.0.0.

Fixes ageitgey/face_recognition#1645